### PR TITLE
First stab at Client Certificates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ install:
 
 .PHONY: build
 build:
-	dune build
+	dune build -p httpkit
 
 .PHONY: watch
 watch:

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Httpkit.Server.(
 I encourage you to read on through the Principles and let me know what you
 think! 🙌🏼
 
-#### Installing
+#### Installing with opam
 
 You can install by pinning with opam:
 
@@ -77,6 +77,33 @@ $ opam pin add httpaf git+https://github.com/anmonteiro/httpaf#cherry-picking
 $ opam pin add httpaf-lwt git+https://github.com/anmonteiro/httpaf#anmonteiro/pluggable-read-write
 $ opam pin add tls git+https://github.com/anmonteiro/ocaml-tls#anmonteiro/fix-reading-last-chunk-when-eof
 ```
+
+#### Installing with esy
+
+You can install by dropping the following dependencies in your `package.json`:
+
+```json
+{
+  "dependencies": {
+    "@opam/httpkit": "*",
+    "@opam/httpkit-lwt": "*",
+    "@opam/logs": "*",
+    "@opam/fmt": "*",
+    // ...
+  },
+  "resolutions": {
+    "@opam/httpkit": "ostera/httpkit:httpkit.opam#555595a",
+    "@opam/httpkit-lwt": "ostera/httpkit:httpkit-lwt.opam#555595a",
+    "@opam/httpaf": "anmonteiro/httpaf:httpaf.opam#57e9dd2",
+    "@opam/httpaf-lwt": "anmonteiro/httpaf:httpaf-lwt.opam#57e9dd2",
+    // ...
+  }
+}
+
+```
+
+> NOTE: Make sure you're using the latest commit hash!
+
 
 ## Common Middleware
 

--- a/README.md
+++ b/README.md
@@ -92,8 +92,8 @@ You can install by dropping the following dependencies in your `package.json`:
     // ...
   },
   "resolutions": {
-    "@opam/httpkit": "ostera/httpkit:httpkit.opam#555595a",
-    "@opam/httpkit-lwt": "ostera/httpkit:httpkit-lwt.opam#555595a",
+    "@opam/httpkit": "ostera/httpkit:httpkit.opam#322ca26",
+    "@opam/httpkit-lwt": "ostera/httpkit:httpkit-lwt.opam#322ca26",
     "@opam/httpaf": "anmonteiro/httpaf:httpaf.opam#57e9dd2",
     "@opam/httpaf-lwt": "anmonteiro/httpaf:httpaf-lwt.opam#57e9dd2",
     // ...

--- a/httpkit-lwt.opam
+++ b/httpkit-lwt.opam
@@ -15,5 +15,5 @@ depends: [
   "dune" {build}
   "reason" {build}
 ]
-build: [make "build"]
-install: [make "install"]
+build: ["dune" "build" "-p" name]
+install: ["dune" "install" name "--prefix" prefix "--root" "."]

--- a/httpkit-lwt.opam
+++ b/httpkit-lwt.opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 name: "httpkit-lwt"
-version: "0.9"
+version: "0.10"
 synopsis: "High-level, High-performance HTTP(S) Clients/Servers with Lwt"
 maintainer: "Leandro Ostera <leandro@ostera.io>"
 authors: "Leandro Ostera <leandro@ostera.io>"

--- a/httpkit.opam
+++ b/httpkit.opam
@@ -13,9 +13,10 @@ depends: [
   "logs"
   "tls"
   "uri"
+  "fpath"
 
   "dune" {build}
   "reason" {build}
 ]
-build: [make "build"]
-install: [make "install"]
+build: ["dune" "build" "-p" name]
+install: ["dune" "install" name "--prefix" prefix "--root" "."]

--- a/httpkit.opam
+++ b/httpkit.opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 name: "httpkit"
-version: "0.9"
+version: "0.10"
 synopsis: "High-level, High-performance HTTP(S) Clients/Servers"
 maintainer: "Leandro Ostera <leandro@ostera.io>"
 authors: "Leandro Ostera <leandro@ostera.io>"

--- a/lwt/client/Http.re
+++ b/lwt/client/Http.re
@@ -1,9 +1,13 @@
 module M: Httpkit.Client.Request.S with type io('a) = Lwt.t('a) =
   Httpkit.Client.Request.Make({
     type io('a) = Lwt.t('a);
-    let send = (~trace as _=?, ~meth=`GET, ~headers=[], ~body=?, uri) => {
-      open Httpaf;
+    let send = (~trace as _=?, req) => {
       open Lwt.Infix;
+      open Httpkit.Client;
+
+      let body = Request.body(req);
+      let uri = Request.uri(req);
+
       let response_handler =
           (notify_response_received, response, response_body) =>
         Lwt.wakeup_later(
@@ -32,19 +36,7 @@ module M: Httpkit.Client.Request.S with type io('a) = Lwt.t('a) =
           Lwt_unix.connect(socket, socket_addr)
           >>= (
             () => {
-              let content_length =
-                switch (body) {
-                | None => "0"
-                | Some(body) => body |> String.length |> string_of_int
-                };
-
-              let headers =
-                Headers.of_list(
-                  [("Host", host), ("Content-Length", content_length)]
-                  @ headers,
-                );
-              let path = uri |> Uri.path_and_query;
-              let request = Request.create(meth, path, ~headers);
+              let request = Request.as_httpaf(req);
 
               let (response_received, notify_response_received) = Lwt.wait();
               let response_handler =
@@ -60,10 +52,12 @@ module M: Httpkit.Client.Request.S with type io('a) = Lwt.t('a) =
                 );
 
               switch (body) {
-              | Some(body) => Body.write_string(request_body, body)
+              | Some(body) => Httpaf.Body.write_string(request_body, body)
               | None => ()
               };
-              Body.flush(request_body, () => Body.close_writer(request_body));
+              Httpaf.Body.flush(request_body, () =>
+                Httpaf.Body.close_writer(request_body)
+              );
 
               /* TODO(@ostera): Better idiom for this? */
               response_received >>= (result => result);

--- a/lwt/client/Http.re
+++ b/lwt/client/Http.re
@@ -1,7 +1,12 @@
-module M: Httpkit.Client.Request.S with type io('a) = Lwt.t('a) =
+module M:
+  Httpkit.Client.Request.S with
+    type io('a) = Lwt.t('a) and type config = unit =
   Httpkit.Client.Request.Make({
     type io('a) = Lwt.t('a);
-    let send = (~trace as _=?, req) => {
+
+    type config = unit;
+
+    let send = (~config as _=?, req) => {
       open Lwt.Infix;
       open Httpkit.Client;
 

--- a/lwt/client/Https.re
+++ b/lwt/client/Https.re
@@ -30,10 +30,13 @@ module Config = {
       tracer,
       tls_client: (req, socket) => {
         let host = Httpkit.Client.Request.uri(req) |> Uri.host_with_default;
-        X509_lwt.authenticator(`Ca_file(cert))
+        X509_lwt.authenticator(`Ca_file(cert |> Fpath.to_string))
         >>= (
           authenticator =>
-            X509_lwt.private_of_pems(~cert, ~priv_key)
+            X509_lwt.private_of_pems(
+              ~cert=cert |> Fpath.to_string,
+              ~priv_key=priv_key |> Fpath.to_string,
+            )
             >>= (
               certificate => {
                 let client =

--- a/lwt/client/Https.re
+++ b/lwt/client/Https.re
@@ -1,3 +1,5 @@
+open Lwt.Infix;
+
 /**
   This module was originally written during one of the [ReasonableCoding]
   live-streams for the Twitchboard project.
@@ -7,71 +9,85 @@
   Loosely based on examples from httpaf-lwt, ocaml-tls, and this gist from
   @anmonteiro: https://gist.github.com/anmonteiro/794d2713e787690ef16c684360a4d39f
   */
-let writev = (tls_client, _fd, io_vecs) =>
-  Lwt.(
-    catch(
-      () => {
-        let {Faraday.len, buffer, off} = io_vecs |> List.hd;
-        Cstruct.of_bigarray(~len, ~off, buffer)
-        |> Tls_lwt.Unix.write(tls_client)
-        >|= (_ => `Ok(len));
-      },
-      exn =>
-        switch (exn) {
-        | Unix.Unix_error(Unix.EBADF, "check_descriptor", _) =>
-          Lwt.return(`Closed)
-        | exn =>
-          Logs_lwt.err(m => m("failed: %s", Printexc.to_string(exn)))
-          >>= (() => Lwt.fail(exn))
-        },
-    )
-  );
 
-let read = (tls_client, fd, buffer) =>
-  Lwt.(
-    catch(
-      () =>
-        Httpaf_lwt.Buffer.put(buffer, ~f=(bigstring, ~off, ~len) =>
-          Tls_lwt.Unix.read_bytes(tls_client, bigstring, off, len)
-        ),
-      exn => {
-        let err = Printexc.to_string(exn);
-        (
-          switch (Lwt_unix.state(fd)) {
-          | Lwt_unix.Closed =>
-            Logs_lwt.err(m => m("Https.read: Socket closed"))
-          | Aborted(exn) =>
-            Logs_lwt.err(m =>
-              m("Https.read: Socket aborted: %s", Printexc.to_string(exn))
-            )
-          | Opened =>
-            Logs_lwt.err(m => m("Https.read: Socket opened! %s", err))
-          }
-        )
+type tls_config = {
+  tracer: option(Tls_lwt.tracer),
+  tls_client:
+    (Httpkit.Client.Request.t, Lwt_unix.file_descr) => Lwt.t(Tls_lwt.Unix.t),
+};
+
+type tls_auth = [
+  | `Ca_dir(string)
+  | `Ca_file(string)
+  | `Hex_key_fingerprints(Nocrypto.Hash.hash, list((string, string)))
+  | `Key_fingerprints(Nocrypto.Hash.hash, list((string, Cstruct.t)))
+  | `No_authentication_I'M_STUPID
+];
+
+module Config = {
+  let from_pems = (~tracer=?, ~cert, ~priv_key, ()) => {
+    {
+      tracer,
+      tls_client: (req, socket) => {
+        let host = Httpkit.Client.Request.uri(req) |> Uri.host_with_default;
+        X509_lwt.authenticator(`Ca_file(cert))
         >>= (
-          _ => {
-            Logs.err(m => m("Https.read: Failing..."));
-            Lwt.async(() => Tls_lwt.Unix.close(tls_client));
-            Lwt.fail(exn);
+          authenticator =>
+            X509_lwt.private_of_pems(~cert, ~priv_key)
+            >>= (
+              certificate => {
+                let client =
+                  Tls.Config.client(
+                    ~authenticator,
+                    ~certificates=`Single(certificate),
+                    (),
+                  );
+                switch (tracer) {
+                | Some(tracer) =>
+                  Tls_lwt.Unix.client_of_fd(
+                    ~trace=tracer,
+                    client,
+                    ~host,
+                    socket,
+                  )
+                | _ => Tls_lwt.Unix.client_of_fd(client, ~host, socket)
+                };
+              }
+            )
+        );
+      },
+    };
+  };
+  let no_auth = (~tracer=?, ()) => {
+    {
+      tracer,
+      tls_client: (req, socket) => {
+        let host = Httpkit.Client.Request.uri(req) |> Uri.host_with_default;
+        X509_lwt.authenticator(`No_authentication_I'M_STUPID)
+        >>= (
+          authenticator => {
+            let client = Tls.Config.client(~authenticator, ());
+            switch (tracer) {
+            | Some(tracer) =>
+              Tls_lwt.Unix.client_of_fd(~trace=tracer, client, ~host, socket)
+            | _ => Tls_lwt.Unix.client_of_fd(client, ~host, socket)
+            };
           }
         );
       },
-    )
-    >|= (
-      bytes_read =>
-        if (bytes_read == 0) {
-          `Eof;
-        } else {
-          `Ok(bytes_read);
-        }
-    )
-  );
+    };
+  };
+};
 
-module M: Httpkit.Client.Request.S with type io('a) = Lwt.t('a) =
+module M:
+  Httpkit.Client.Request.S with
+    type io('a) = Lwt.t('a) and type config = tls_config =
   Httpkit.Client.Request.Make({
     type io('a) = Lwt.t('a);
-    let send = (~trace=?, req) => {
-      open Lwt.Infix;
+
+    type config = tls_config;
+
+    let send = (~config=?, req) => {
       open Httpkit.Client;
 
       let body = Request.body(req);
@@ -98,19 +114,11 @@ module M: Httpkit.Client.Request.S with type io('a) = Lwt.t('a) =
           let socket = Lwt_unix.socket(Unix.PF_INET, Unix.SOCK_STREAM, 0);
 
           Lwt_unix.connect(socket, socket_addr)
-          >>= (_ => X509_lwt.authenticator(`No_authentication_I'M_STUPID))
           >>= (
-            authenticator => {
-              let client = Tls.Config.client(~authenticator, ());
-              switch (trace) {
-              | Some(tracer) =>
-                Tls_lwt.Unix.client_of_fd(
-                  ~trace=tracer,
-                  client,
-                  ~host,
-                  socket,
-                )
-              | None => Tls_lwt.Unix.client_of_fd(client, ~host, socket)
+            _ => {
+              switch (config) {
+              | Some({tls_client, _}) => tls_client(req, socket)
+              | None => Config.no_auth().tls_client(req, socket)
               };
             }
           )
@@ -125,8 +133,8 @@ module M: Httpkit.Client.Request.S with type io('a) = Lwt.t('a) =
 
               let request_body =
                 Httpaf_lwt.Client.request(
-                  ~writev=writev(tls_client),
-                  ~read=read(tls_client),
+                  ~writev=Tls_io.writev(tls_client),
+                  ~read=Tls_io.read(tls_client),
                   socket,
                   request,
                   ~error_handler,

--- a/lwt/client/Tls_io.re
+++ b/lwt/client/Tls_io.re
@@ -1,0 +1,59 @@
+let writev = (tls_client, _fd, io_vecs) =>
+  Lwt.(
+    catch(
+      () => {
+        let {Faraday.len, buffer, off} = io_vecs |> List.hd;
+        Cstruct.of_bigarray(~len, ~off, buffer)
+        |> Tls_lwt.Unix.write(tls_client)
+        >|= (_ => `Ok(len));
+      },
+      exn =>
+        switch (exn) {
+        | Unix.Unix_error(Unix.EBADF, "check_descriptor", _) =>
+          Lwt.return(`Closed)
+        | exn =>
+          Logs_lwt.err(m => m("failed: %s", Printexc.to_string(exn)))
+          >>= (() => Lwt.fail(exn))
+        },
+    )
+  );
+
+let read = (tls_client, fd, buffer) =>
+  Lwt.(
+    catch(
+      () =>
+        Httpaf_lwt.Buffer.put(buffer, ~f=(bigstring, ~off, ~len) =>
+          Tls_lwt.Unix.read_bytes(tls_client, bigstring, off, len)
+        ),
+      exn => {
+        let err = Printexc.to_string(exn);
+        (
+          switch (Lwt_unix.state(fd)) {
+          | Lwt_unix.Closed =>
+            Logs_lwt.err(m => m("Https.read: Socket closed"))
+          | Aborted(exn) =>
+            Logs_lwt.err(m =>
+              m("Https.read: Socket aborted: %s", Printexc.to_string(exn))
+            )
+          | Opened =>
+            Logs_lwt.err(m => m("Https.read: Socket opened! %s", err))
+          }
+        )
+        >>= (
+          _ => {
+            Logs.err(m => m("Https.read: Failing..."));
+            Lwt.async(() => Tls_lwt.Unix.close(tls_client));
+            Lwt.fail(exn);
+          }
+        );
+      },
+    )
+    >|= (
+      bytes_read =>
+        if (bytes_read == 0) {
+          `Eof;
+        } else {
+          `Ok(bytes_read);
+        }
+    )
+  );

--- a/lwt/client/dune
+++ b/lwt/client/dune
@@ -1,5 +1,5 @@
 (library
   (name httpkit_lwt_client)
-  (public_name httpkit.lwt.client)
+  (public_name httpkit-lwt.client)
   (libraries httpkit httpaf-lwt lwt lwt.unix tls tls.lwt uri logs logs.lwt fpath))
 

--- a/lwt/client/dune
+++ b/lwt/client/dune
@@ -1,5 +1,5 @@
 (library
   (name httpkit_lwt_client)
   (public_name httpkit.lwt.client)
-  (libraries httpkit httpaf-lwt lwt lwt.unix tls tls.lwt uri logs logs.lwt))
+  (libraries httpkit httpaf-lwt lwt lwt.unix tls tls.lwt uri logs logs.lwt fpath))
 

--- a/lwt/dune
+++ b/lwt/dune
@@ -1,4 +1,4 @@
 (library
   (name httpkit_lwt)
-  (public_name httpkit.lwt)
-  (libraries httpkit httpkit.lwt.client httpkit.lwt.server))
+  (public_name httpkit-lwt)
+  (libraries httpkit httpkit-lwt.client httpkit-lwt.server))

--- a/lwt/server/dune
+++ b/lwt/server/dune
@@ -1,5 +1,5 @@
 (library
   (name httpkit_lwt_server)
-  (public_name httpkit.lwt.server)
+  (public_name httpkit-lwt.server)
   (libraries httpkit httpaf-lwt lwt lwt.unix tls tls.lwt))
 

--- a/src/client/Request.re
+++ b/src/client/Request.re
@@ -48,9 +48,11 @@ module type S = {
 
   let send:
     (~config: config=?, t) =>
-    Lwt_result.t(
-      (Httpaf.Response.t, Httpaf.Body.t([ | `read])),
-      [> | `Connection_error(Httpaf.Client_connection.error)],
+    io(
+      result(
+        (Httpaf.Response.t, Httpaf.Body.t([ | `read])),
+        [> | `Connection_error(Httpaf.Client_connection.error)],
+      ),
     );
 };
 

--- a/src/client/Request.re
+++ b/src/client/Request.re
@@ -1,14 +1,51 @@
+type t = {
+  req: Httpaf.Request.t,
+  uri: Uri.t,
+  body: option(string),
+  headers: list((string, string)),
+};
+
+let create:
+  (
+    ~headers: list((string, string))=?,
+    ~body: string=?,
+    Httpaf.Method.t,
+    Uri.t
+  ) =>
+  t =
+  (~headers=[], ~body="", meth, uri) => {
+    let host = Uri.host_with_default(uri);
+    let content_length = body |> String.length |> string_of_int;
+    let headers =
+      [("Host", host), ("Content-Length", content_length)] @ headers;
+
+    {
+      req:
+        Httpaf.Request.create(
+          ~headers=Httpaf.Headers.of_list(headers),
+          meth,
+          uri |> Uri.to_string,
+        ),
+      uri,
+      headers,
+      body:
+        switch (body) {
+        | "" => None
+        | _ => Some(body)
+        },
+    };
+  };
+
+let as_httpaf = req => req.req;
+let body = req => req.body;
+let headers = req => req.headers;
+let uri = req => req.uri;
+
 module type S = {
   type io('a);
 
   let send:
-    (
-      ~trace: Tls_lwt.tracer=?,
-      ~meth: Httpaf.Method.t=?,
-      ~headers: list((string, string))=?,
-      ~body: string=?,
-      Uri.t
-    ) =>
+    (~trace: Tls_lwt.tracer=?, t) =>
     Lwt_result.t(
       (Httpaf.Response.t, Httpaf.Body.t([ | `read])),
       [> | `Connection_error(Httpaf.Client_connection.error)],

--- a/src/client/Request.re
+++ b/src/client/Request.re
@@ -44,16 +44,22 @@ let uri = req => req.uri;
 module type S = {
   type io('a);
 
+  type config;
+
   let send:
-    (~trace: Tls_lwt.tracer=?, t) =>
+    (~config: config=?, t) =>
     Lwt_result.t(
       (Httpaf.Response.t, Httpaf.Body.t([ | `read])),
       [> | `Connection_error(Httpaf.Client_connection.error)],
     );
 };
 
-module Make = (M: S) : (S with type io('a) = M.io('a)) => {
+module Make =
+       (M: S)
+       : (S with type io('a) = M.io('a) and type config = M.config) => {
   type io('a) = M.io('a);
+
+  type config = M.config;
 
   let send = M.send;
 };

--- a/src/client/dune
+++ b/src/client/dune
@@ -1,8 +1,4 @@
 (library
   (name httpkit_client)
   (public_name httpkit.client)
-  (libraries
-    fmt logs logs.lwt
-    httpaf httpaf-lwt tls tls.lwt uri
-    lwt lwt.unix
-    ))
+  (libraries fmt logs httpaf uri))

--- a/tools/Request.re
+++ b/tools/Request.re
@@ -8,6 +8,12 @@ Fmt_tty.setup_std_outputs();
 Logs.set_level(Some(Logs.Debug));
 Logs.set_reporter(Logs_fmt.reporter());
 
+/**
+
+  Sample HTTPS Request using No Authentication :tm:
+
+*/
+
 let https_url = "https://api.github.com/users/ostera";
 Logs.app(m => m("Requesting: %s", https_url));
 switch (
@@ -27,6 +33,44 @@ switch (
 | Error(_) => Logs.err(m => m("Something went wrong!!!"))
 };
 
+/**
+
+  Sample HTTPS Request using an Authentication config from
+  files.
+
+*/
+
+let https_url = "https://api.github.com/users/ostera";
+let tls_config =
+  Httpkit_lwt.Client.Https.Config.from_pems(
+    ~cert="./cert.pem",
+    ~priv_key="./priv_key",
+    (),
+  );
+
+Logs.app(m => m("Requesting: %s", https_url));
+switch (
+  Httpkit_lwt.Client.(
+    Httpkit.Client.Request.create(
+      ~headers=[("User-Agent", "Reason HttpKit")],
+      `GET,
+      https_url |> Uri.of_string,
+    )
+    |> Https.(send(~config=tls_config))
+    >>= Response.body
+    |> Lwt_main.run
+  )
+) {
+| exception e => Logs.err(m => m("%s", Printexc.to_string(e)))
+| Ok(body) => Logs.app(m => m("Response: %s", body))
+| Error(_) => Logs.err(m => m("Something went wrong!!!"))
+};
+
+/**
+
+  Sample HTTP Request.
+
+*/
 /* NOTE: the HelloWorld server in tools/HelloWorld.re can help you run this :) */
 let http_url = "http://localhost:9999/awesome/posum";
 Logs.app(m => m("Requesting: %s", http_url));

--- a/tools/Request.re
+++ b/tools/Request.re
@@ -43,8 +43,8 @@ switch (
 let https_url = "https://api.github.com/users/ostera";
 let tls_config =
   Httpkit_lwt.Client.Https.Config.from_pems(
-    ~cert="./cert.pem",
-    ~priv_key="./priv_key",
+    ~cert="./cert.pem" |> Fpath.v,
+    ~priv_key="./priv_key" |> Fpath.v,
     (),
   );
 

--- a/tools/Request.re
+++ b/tools/Request.re
@@ -12,9 +12,12 @@ let https_url = "https://api.github.com/users/ostera";
 Logs.app(m => m("Requesting: %s", https_url));
 switch (
   Httpkit_lwt.Client.(
-    https_url
-    |> Uri.of_string
-    |> Https.send(~headers=[("User-Agent", "Reason HttpKit")])
+    Httpkit.Client.Request.create(
+      ~headers=[("User-Agent", "Reason HttpKit")],
+      `GET,
+      https_url |> Uri.of_string,
+    )
+    |> Https.send
     >>= Response.body
     |> Lwt_main.run
   )
@@ -26,12 +29,15 @@ switch (
 
 /* NOTE: the HelloWorld server in tools/HelloWorld.re can help you run this :) */
 let http_url = "http://localhost:9999/awesome/posum";
-Logs.app(m => m("Requesting: %s", https_url));
+Logs.app(m => m("Requesting: %s", http_url));
 switch (
   Httpkit_lwt.Client.(
-    http_url
-    |> Uri.of_string
-    |> Http.send(~headers=[("User-Agent", "Reason HttpKit")])
+    Httpkit.Client.Request.create(
+      ~headers=[("User-Agent", "Reason HttpKit")],
+      `GET,
+      http_url |> Uri.of_string,
+    )
+    |> Http.send
     >>= Response.body
     |> Lwt_main.run
   )

--- a/tools/dune
+++ b/tools/dune
@@ -4,7 +4,7 @@
   (modules HelloWorld)
   (public_name helloworld)
 	(ocamlopt_flags -O3)
-  (libraries httpkit.lwt httpkit logs.fmt fmt.tty lwt))
+  (libraries httpkit-lwt httpkit logs.fmt fmt.tty lwt))
 
 (executable
   (package httpkit-lwt)
@@ -12,7 +12,7 @@
   (public_name request)
   (modules Request)
 	(ocamlopt_flags -O3)
-  (libraries httpkit.lwt httpkit logs.fmt fmt.tty fpath))
+  (libraries httpkit-lwt httpkit logs.fmt fmt.tty fpath))
 
 (executable
   (package httpkit-lwt)
@@ -20,7 +20,7 @@
   (modules EchoServer)
   (public_name echottp)
 	(ocamlopt_flags -O3)
-  (libraries httpkit.lwt httpkit logs.fmt fmt.tty lwt))
+  (libraries httpkit-lwt httpkit logs.fmt fmt.tty lwt))
 
 (executable
   (package httpkit-lwt)

--- a/tools/dune
+++ b/tools/dune
@@ -28,4 +28,4 @@
   (modules RawEchoServer)
   (public_name rawechottp)
 	(ocamlopt_flags -O3)
-  (libraries httpkit httpaf logs.fmt fmt.tty lwt))
+  (libraries httpkit httpaf httpaf-lwt logs.fmt fmt.tty lwt))

--- a/tools/dune
+++ b/tools/dune
@@ -12,7 +12,7 @@
   (public_name request)
   (modules Request)
 	(ocamlopt_flags -O3)
-  (libraries httpkit.lwt httpkit logs.fmt fmt.tty))
+  (libraries httpkit.lwt httpkit logs.fmt fmt.tty fpath))
 
 (executable
   (package httpkit-lwt)


### PR DESCRIPTION
Hope this makes some sense @ulrikstrid!

I've modified the `tools/Request.re` as well to showcase how this should be used, but I'm not entirely comfortable.

It made sense to include more data into the Request.t, but keep the TLS config to the Https module to avoid unnecessary allocations when sending more than one request. This is of course debatable, but part of the HttpKit contract is that it should be fast. We'll see how this holds!

The ergonomics are okay I think but I'd like to put it to use first.