### PR TITLE
Add -p flag to dune build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ install:
 
 .PHONY: build
 build:
-	dune build
+	dune build -p httpkit
 
 .PHONY: watch
 watch:


### PR DESCRIPTION
Also need to clean up stray `lwt` in the base library in client to get this buildable (at least in `esy`)