### PR TITLE
since tls 0.9.3, the specific issue (error after eof) has been fixed

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,6 @@ dependencies:
 ```sh
 $ opam pin add httpaf git+https://github.com/anmonteiro/httpaf#cherry-picking
 $ opam pin add httpaf-lwt git+https://github.com/anmonteiro/httpaf#anmonteiro/pluggable-read-write
-$ opam pin add tls git+https://github.com/anmonteiro/ocaml-tls#anmonteiro/fix-reading-last-chunk-when-eof
 ```
 
 #### Installing with esy


### PR DESCRIPTION
see https://github.com/mirleft/ocaml-tls/pull/388 for the applied fix