### PR TITLE
depend on tls 0.9.3 which doesn't error after eof

### DIFF
--- a/httpkit.opam
+++ b/httpkit.opam
@@ -11,7 +11,7 @@ depends: [
   "fmt"
   "httpaf"
   "logs"
-  "tls"
+  "tls" {>= "0.9.3"}
   "uri"
   "fpath"
 


### PR DESCRIPTION
to avoid a bad user experience where they run into the issue mentioned