### PR TITLE
[docs] Clarify esy install instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ You can install by dropping the following dependencies in your `package.json`:
 
 ```
 
-> NOTE: Make sure you're using the latest commit hash!
+> NOTE: For `httpkit` make sure you're using the latest commit hash!
 
 
 ## Common Middleware


### PR DESCRIPTION
Ran into errors when trying to use the latest commit-hashes on `httpaf`, maybe this could prevent others from making the same mistake. 🙂 