### PR TITLE
[readme] add >>= client request scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ In short:
 For making a request:
 
 ```reason
+open Lwt_result.Infix;
+
 let req =
   Httpkit.Client.Request.create(
     ~headers=[("User-Agent", "Reason HttpKit")],


### PR DESCRIPTION
Adds `Lwt_result.Infix` open in the client example snippet. It was hard for me to find if it comes from `Lwt.Infix` or other custom operators library. Make things easier to test our 🙂  